### PR TITLE
Add trial-level TFR plot sorted by ratings

### DIFF
--- a/04_behavior_feature_analysis.py
+++ b/04_behavior_feature_analysis.py
@@ -345,6 +345,91 @@ def plot_psychometrics(subject: str, task: str = TASK) -> None:
 
 
 # -----------------------------------------------------------------------------
+# Trial-level TFR sorted by rating
+# -----------------------------------------------------------------------------
+
+def plot_tfr_sorted_by_rating(subject: str, task: str = TASK, channel: str = "Cz") -> None:
+    """Plot per-trial TFR power for a channel sorted by behavioral ratings."""
+
+    plots_dir = _plots_dir(subject)
+    _ensure_dir(plots_dir)
+
+    # ------------------------------------------------------------------
+    # Load epochs
+    epo_path = _find_clean_epochs_path(subject, task)
+    if epo_path is None:
+        print(f"No cleaned epochs found for sub-{subject}, task-{task}")
+        return
+    epochs = mne.read_epochs(epo_path, preload=True, verbose=False)
+
+    # ------------------------------------------------------------------
+    # Load and align ratings to epochs
+    events = _load_events_df(subject, task)
+    events = _align_events_to_epochs(events, epochs)
+    rating_col = _pick_first_column(events, RATING_COLUMNS) if events is not None else None
+    if rating_col is None:
+        print(f"TFR sorted by rating: no rating column found for sub-{subject}")
+        return
+    ratings = pd.to_numeric(events[rating_col], errors="coerce").to_numpy()
+    valid = ~np.isnan(ratings)
+    if valid.sum() == 0:
+        print(f"TFR sorted by rating: no valid ratings for sub-{subject}")
+        return
+    epochs = epochs[valid]
+    ratings = ratings[valid]
+
+    # ------------------------------------------------------------------
+    # Compute trial-level TFR
+    freqs = np.linspace(4.0, 40.0, 20)
+    n_cycles = freqs / 2.0
+    power = mne.time_frequency.tfr_morlet(
+        epochs,
+        freqs=freqs,
+        n_cycles=n_cycles,
+        use_fft=True,
+        return_itc=False,
+        average=False,
+        decim=2,
+        n_jobs=1,
+        picks="eeg",
+        verbose=False,
+    )
+
+    if channel not in power.ch_names:
+        print(f"Channel {channel} not found for sub-{subject}")
+        return
+
+    ch_idx = power.ch_names.index(channel)
+    data = power.data[:, ch_idx, :, :]  # (n_trials, n_freqs, n_times)
+    data = data.mean(axis=1)  # average over frequency -> (n_trials, n_times)
+
+    order = np.argsort(ratings)
+    data = data[order]
+    ratings_sorted = ratings[order]
+
+    # ------------------------------------------------------------------
+    # Plot heatmap
+    fig, ax = plt.subplots(figsize=(6, 4))
+    sns.heatmap(data, ax=ax, cmap="viridis", cbar_kws={"label": "Power"})
+
+    times = power.times
+    xticks = np.linspace(0, len(times) - 1, 5, dtype=int)
+    ax.set_xticks(xticks)
+    ax.set_xticklabels([f"{times[i]:.1f}" for i in xticks])
+
+    yticks = np.linspace(0, len(ratings_sorted) - 1, min(10, len(ratings_sorted)), dtype=int)
+    ax.set_yticks(yticks + 0.5)
+    ax.set_yticklabels([f"{ratings_sorted[i]:.1f}" for i in yticks])
+
+    ax.set_xlabel("Time (s)")
+    ax.set_ylabel("Rating (sorted)")
+    ax.set_title(f"{channel} power sorted by rating")
+
+    fname = f"tfr_sorted_by_rating_{_sanitize(channel)}"
+    _save_fig(fig, plots_dir / fname)
+
+
+# -----------------------------------------------------------------------------
 # Correlation: power features -> topographic maps
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- add `plot_tfr_sorted_by_rating` visualization helper
- compute per-trial Morlet TFR, align behavioral ratings, and plot Cz power sorted by rating

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b10c0a8d888331b712e14d28f1ec9b