### PR TITLE
Ensure baseline windows precede stimulus onset

### DIFF
--- a/eeg_config.yaml
+++ b/eeg_config.yaml
@@ -28,7 +28,7 @@ frequency_bands:
 power:
   bands_to_use: ["theta", "alpha", "beta", "gamma"]  # Subset of frequency_bands for power features
   plateau_window: [0.0, 10.0]  # Time window for plateau analysis (seconds)
-  baseline_window: [-5.0, 0.0]  # Baseline window (seconds)
+  baseline_window: [-5.0, -0.1]  # Baseline window (seconds)
   
 # Event column mappings for behavioral data
 event_columns:
@@ -322,7 +322,7 @@ analysis:
   # Time-frequency analysis
   time_frequency:
     default_temperature_strategy: "pooled"  # "pooled", "per", "both"
-    baseline_window: [-5.0, 0.0]  # TFR baseline window
+    baseline_window: [-5.0, -0.1]  # TFR baseline window
     default_plateau_tmin: 0.0
     default_plateau_tmax: 10.0
     # TFR computation

--- a/tests/test_baseline_validation.py
+++ b/tests/test_baseline_validation.py
@@ -1,0 +1,31 @@
+import numpy as np
+import importlib.util
+from pathlib import Path
+import sys
+import pytest
+
+# Ensure project root on path and dynamically load module
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.append(str(ROOT))
+spec = importlib.util.spec_from_file_location("tfa", ROOT / "02_time_frequency_analysis.py")
+tfa = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tfa)
+
+
+def test_baseline_mask_valid():
+    times = np.linspace(-5, 5, 101)
+    b_start, b_end, mask = tfa._validate_baseline_indices(times, (-5.0, -0.1))
+    assert b_end < 0
+    assert mask.sum() == np.sum((times >= b_start) & (times < b_end))
+
+
+def test_baseline_mask_invalid_end():
+    times = np.linspace(-5, 5, 101)
+    with pytest.raises(ValueError):
+        tfa._validate_baseline_indices(times, (-5.0, 0.0))
+
+
+def test_baseline_mask_insufficient_samples():
+    times = np.linspace(-5, -4, 4)  # Only 4 samples in baseline region
+    with pytest.raises(ValueError):
+        tfa._validate_baseline_indices(times, (-5.0, -0.1))


### PR DESCRIPTION
## Summary
- Crop baseline strictly before stimulus onset when plotting baseline vs. stimulus power
- Validate baseline window end and sample count during time-frequency analysis
- Move baseline windows in config to end before 0s and add unit tests for baseline validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b738b0dce08331964a54f7f282e752