### PR TITLE
Clarify decibel units in baseline power plots

### DIFF
--- a/02_time_frequency_analysis.py
+++ b/02_time_frequency_analysis.py
@@ -1008,17 +1008,21 @@ def contrast_pain_nonpain(
         try:
             sm_pn = ScalarMappable(norm=mcolors.TwoSlopeNorm(vmin=-vabs_pn, vcenter=0.0, vmax=vabs_pn), cmap=TOPO_CMAP)
             sm_pn.set_array([])
-            cbar_pn = fig.colorbar(sm_pn, ax=[axes[r, 0], axes[r, 1]], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD)
+            cbar_pn = fig.colorbar(
+                sm_pn, ax=[axes[r, 0], axes[r, 1]], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD
+            )
             try:
-                cbar_pn.set_label("log10(power/baseline)")
+                cbar_pn.set_label("10·log10(power/baseline) (dB)")
             except Exception:
                 pass
             if diff_abs > 0:
                 sm_diff = ScalarMappable(norm=mcolors.TwoSlopeNorm(vmin=-diff_abs, vcenter=0.0, vmax=diff_abs), cmap=TOPO_CMAP)
                 sm_diff.set_array([])
-                cbar_diff = fig.colorbar(sm_diff, ax=axes[r, 3], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD)
+                cbar_diff = fig.colorbar(
+                    sm_diff, ax=axes[r, 3], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD
+                )
                 try:
-                    cbar_diff.set_label("log10(power/baseline)")
+                    cbar_diff.set_label("10·log10(power/baseline) (dB)")
                 except Exception:
                     pass
         except Exception:
@@ -1039,7 +1043,7 @@ def contrast_maxmin_temperature(
     baseline: Tuple[Optional[float], Optional[float]] = BASELINE,
     plateau_window: Tuple[float, float] = (DEFAULT_PLATEAU_TMIN, DEFAULT_PLATEAU_TMAX),
 ) -> None:
-    """Topomap grid comparing highest vs lowest temperature (Δ=log10(power/baseline)).
+    """Topomap grid comparing highest vs lowest temperature (Δ=10·log10(power/baseline) (dB)).
 
     Layout mirrors pain/non-pain grid: [Max temp, Min temp, spacer, Max - Min] across alpha/beta/gamma.
     """
@@ -1200,17 +1204,21 @@ def contrast_maxmin_temperature(
         try:
             sm_pn = ScalarMappable(norm=mcolors.Normalize(vmin=vmin, vmax=vmax), cmap=TOPO_CMAP)
             sm_pn.set_array([])
-            cbar_pn = fig.colorbar(sm_pn, ax=[axes[r, 0], axes[r, 1]], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD)
+            cbar_pn = fig.colorbar(
+                sm_pn, ax=[axes[r, 0], axes[r, 1]], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD
+            )
             try:
-                cbar_pn.set_label("log10(power/baseline)")
+                cbar_pn.set_label("10·log10(power/baseline) (dB)")
             except Exception:
                 pass
             if diff_abs > 0:
                 sm_diff = ScalarMappable(norm=mcolors.TwoSlopeNorm(vmin=-diff_abs, vcenter=0.0, vmax=diff_abs), cmap=TOPO_CMAP)
                 sm_diff.set_array([])
-                cbar_diff = fig.colorbar(sm_diff, ax=axes[r, 3], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD)
+                cbar_diff = fig.colorbar(
+                    sm_diff, ax=axes[r, 3], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD
+                )
                 try:
-                    cbar_diff.set_label("log10(power/baseline)")
+                    cbar_diff.set_label("10·log10(power/baseline) (dB)")
                 except Exception:
                     pass
         except Exception:
@@ -1377,17 +1385,21 @@ def contrast_pain_nonpain_topomaps_rois(
             try:
                 sm_pn = ScalarMappable(norm=mcolors.Normalize(vmin=vmin, vmax=vmax), cmap=TOPO_CMAP)
                 sm_pn.set_array([])
-                cbar_pn = fig.colorbar(sm_pn, ax=[axes[r, 0], axes[r, 1]], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD)
+                cbar_pn = fig.colorbar(
+                    sm_pn, ax=[axes[r, 0], axes[r, 1]], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD
+                )
                 try:
-                    cbar_pn.set_label("log10(power/baseline)")
+                    cbar_pn.set_label("10·log10(power/baseline) (dB)")
                 except Exception:
                     pass
                 if diff_abs > 0:
                     sm_diff = ScalarMappable(norm=mcolors.TwoSlopeNorm(vmin=-diff_abs, vcenter=0.0, vmax=diff_abs), cmap=TOPO_CMAP)
                     sm_diff.set_array([])
-                    cbar_diff = fig.colorbar(sm_diff, ax=axes[r, 3], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD)
+                    cbar_diff = fig.colorbar(
+                        sm_diff, ax=axes[r, 3], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD
+                    )
                     try:
-                        cbar_diff.set_label("log10(power/baseline)")
+                        cbar_diff.set_label("10·log10(power/baseline) (dB)")
                     except Exception:
                         pass
             except Exception:
@@ -1398,7 +1410,12 @@ def contrast_pain_nonpain_topomaps_rois(
             fig.supylabel("Frequency bands", fontsize=10)
         except Exception:
             pass
-        _save_fig(fig, out_dir, f"topomap_ROI-{_sanitize(roi)}_grid_bands_pain_non_diff_baseline_logratio.png", formats=["png", "svg"])
+        _save_fig(
+            fig,
+            out_dir,
+            f"topomap_ROI-{_sanitize(roi)}_grid_bands_pain_non_diff_baseline_logratio.png",
+            formats=["png", "svg"],
+        )
 
 def _epochs_mean_roi(epochs: mne.Epochs, roi_name: str, roi_chs: list[str]) -> Optional[mne.Epochs]:
     """Create an Epochs object with a single virtual channel as the mean of ROI channels."""
@@ -1565,7 +1582,7 @@ def plot_topomaps_rois_all_trials(
             sm.set_array([])
             cbar = fig.colorbar(sm, ax=axes[r, 0], fraction=COLORBAR_FRACTION, pad=COLORBAR_PAD)
             try:
-                cbar.set_label("log10(power/baseline)")
+                cbar.set_label("10·log10(power/baseline) (dB)")
             except Exception:
                 pass
         except Exception:
@@ -1586,7 +1603,7 @@ def plot_topomap_grid_baseline_temps(
     baseline: Tuple[Optional[float], Optional[float]] = BASELINE,
     plateau_window: Tuple[float, float] = (DEFAULT_PLATEAU_TMIN, DEFAULT_PLATEAU_TMAX),
 ) -> None:
-    """Topomap grid of Δ=log10(power/baseline) by temperature (no baseline column).
+    """Topomap grid of Δ=10·log10(power/baseline) (dB) by temperature (no baseline column).
 
     - Columns: All trials (Δ) followed by each temperature level (Δ), per frequency band.
     - Layout made more compact horizontally by reducing inter-column spacing.
@@ -1712,9 +1729,11 @@ def plot_topomap_grid_baseline_temps(
         try:
             sm_diff = ScalarMappable(norm=mcolors.TwoSlopeNorm(vmin=-diff_abs, vcenter=0.0, vmax=diff_abs), cmap=TOPO_CMAP)
             sm_diff.set_array([])
-            cbar_d = fig.colorbar(sm_diff, ax=axes[r, :].ravel().tolist(), fraction=0.045, pad=0.06, shrink=0.9)
+            cbar_d = fig.colorbar(
+                sm_diff, ax=axes[r, :].ravel().tolist(), fraction=0.045, pad=0.06, shrink=0.9
+            )
             try:
-                cbar_d.set_label("log10(power/baseline)")
+                cbar_d.set_label("10·log10(power/baseline) (dB)")
             except Exception:
                 pass
         except Exception:
@@ -1722,7 +1741,7 @@ def plot_topomap_grid_baseline_temps(
 
     try:
         fig.suptitle(
-            f"Topomaps by temperature: \u0394=log10(power/baseline) over plateau t=[{tmin:.1f}, {tmax:.1f}] s",
+            f"Topomaps by temperature: \u0394=10·log10(power/baseline) (dB) over plateau t=[{tmin:.1f}, {tmax:.1f}] s",
             fontsize=12,
         )
     except Exception:

--- a/03_feature_engineering.py
+++ b/03_feature_engineering.py
@@ -401,7 +401,7 @@ def plot_power_distributions(pow_df: pd.DataFrame, bands: List[str], subject: st
             
             axes[i].axhline(y=0, color='red', linestyle='--', alpha=0.7, label='Baseline')
             axes[i].set_title(f'{band.capitalize()} Power Distribution\n(All channels, all trials)')
-            axes[i].set_ylabel('log10(power/baseline)')
+            axes[i].set_ylabel('10·log10(power/baseline) (dB)')
             axes[i].set_xticks([])
             axes[i].grid(True, alpha=0.3)
             
@@ -463,10 +463,10 @@ def plot_channel_power_heatmap(pow_df: pd.DataFrame, bands: List[str], subject: 
         ax.set_xticklabels(channel_names, rotation=45, ha='right')
         ax.set_yticks(range(len(valid_bands)))
         ax.set_yticklabels([b.capitalize() for b in valid_bands])
-        ax.set_title(f'Mean Power per Channel and Band\n(log10(power/baseline))')
-        
+        ax.set_title(f'Mean Power per Channel and Band\n(10·log10(power/baseline) (dB))')
+
         # Add colorbar
-        cbar = plt.colorbar(im, ax=ax, label='log10(power/baseline)', shrink=0.8)
+        cbar = plt.colorbar(im, ax=ax, label='10·log10(power/baseline) (dB)', shrink=0.8)
         
         # Add text annotations for values (only if not too many)
         if len(channel_names) * len(valid_bands) <= 200:  # Avoid overcrowding
@@ -509,9 +509,15 @@ def plot_tfr_spectrograms_roi(tfr, subject: str, save_dir: Path, logger: logging
             tfr_ch = tfr.copy().pick_channels([ch]).average()
             
             # Create spectrogram plot
-            tfr_ch.plot(picks=[0], axes=axes[i], show=False, colorbar=True,
-                       title=f'{ch} - log10(power/baseline)', 
-                       vlim=(-0.5, 0.5), cmap='RdBu_r')  # Symmetric around 0 for logratio
+            tfr_ch.plot(
+                picks=[0],
+                axes=axes[i],
+                show=False,
+                colorbar=True,
+                title=f'{ch} - 10·log10(power/baseline) (dB)',
+                vlim=(-0.5, 0.5),
+                cmap='RdBu_r',
+            )  # Symmetric around 0 for logratio
             
             # Add vertical lines for key time points
             axes[i].axvline(x=0, color='black', linestyle='--', alpha=0.7, label='Stimulus onset')
@@ -742,7 +748,7 @@ def plot_trial_power_variability(pow_df: pd.DataFrame, bands: List[str], subject
             axes[i].fill_between(trial_nums, mean_power - std_power, mean_power + std_power, 
                                alpha=0.2, color='red', label=f'±1 SD = ±{std_power:.3f}')
             
-            axes[i].set_ylabel(f'{band.capitalize()}\nlog10(power/baseline)')
+            axes[i].set_ylabel(f'{band.capitalize()}\n10·log10(power/baseline) (dB)')
             axes[i].set_title(f'{band.capitalize()} Band Power Variability (CV = {cv_power:.3f})')
             axes[i].grid(True, alpha=0.3)
             axes[i].legend()
@@ -1020,7 +1026,7 @@ def process_subject(subject: str, task: str = TASK) -> None:
     # Keep a copy of raw TFR before baseline correction for comparison plots
     tfr_raw = tfr.copy()
     
-    # Normalize to pre-stimulus baseline as log10(power/baseline) for comparability
+    # Normalize to pre-stimulus baseline as 10·log10(power/baseline) (dB) for comparability
     # Baseline window: -5.0 to 0.0 s, where 0 is stimulus onset
     try:
         tfr.apply_baseline(baseline=(-5.0, 0.0), mode='logratio')
@@ -1157,7 +1163,7 @@ def process_subject(subject: str, task: str = TASK) -> None:
     logger.info(
         f"Done: sub-{subject}, n_trials={n}, n_direct_features={pow_df.shape[1]}, "
         f"n_conn_features={(conn_df.shape[1] if conn_df is not None and len(conn_df) > 0 else 0)}, "
-        f"n_all_features={X_all.shape[1]} (power = log10(power/baseline [-5–0 s]))"
+        f"n_all_features={X_all.shape[1]} (power = 10·log10(power/baseline [-5–0 s]) (dB))"
     )
 
 

--- a/04_behavior_feature_analysis.py
+++ b/04_behavior_feature_analysis.py
@@ -85,23 +85,24 @@ def _save_fig(fig: matplotlib.figure.Figure, path_base: Path | str, formats: Tup
     plt.close(fig)
 
 
-def _logratio_to_pct(v):
-    """Transform log10(power/baseline) to percent change.
+def _db_to_pct(v):
+    """Transform 10·log10(power/baseline) (dB) to percent change.
 
     Accepts scalar or array-like. Returns values in percent.
     """
-    return (np.power(10.0, v) - 1.0) * 100.0
+    v_arr = np.asarray(v, dtype=float)
+    return (np.power(10.0, v_arr / 10.0) - 1.0) * 100.0
 
 
-def _pct_to_logratio(p):
-    """Inverse transform: percent change to log10(power/baseline).
+def _pct_to_db(p):
+    """Inverse transform: percent change to 10·log10(power/baseline) (dB).
 
     Accepts scalar or array-like. Clips 1 + p/100 to a small positive
     minimum (1e-9) to avoid log10 of non-positive values, which previously
     caused runtime warnings when percent was <= -100.
     """
     p_arr = np.asarray(p, dtype=float)
-    return np.log10(np.clip(1.0 + (p_arr / 100.0), 1e-9, None))
+    return 10.0 * np.log10(np.clip(1.0 + (p_arr / 100.0), 1e-9, None))
 
 
 def _find_connectivity_path(subject: str, task: str) -> Path:
@@ -1218,13 +1219,13 @@ def plot_power_roi_scatter(
         show_pct_axis = False
         if not is_partial_residuals and "log10(power" in x_label:
             show_pct_axis = True
-        elif is_partial_residuals and method_code == "pearson" and "residuals of log10(power" in x_label:
+        elif is_partial_residuals and method_code == "pearson" and "residuals of 10·log10(power" in x_label:
             show_pct_axis = True
             
         if show_pct_axis:
             try:
                 # Add percentage axis on top histogram
-                ax_pct = ax_histx.secondary_xaxis('top', functions=(_logratio_to_pct, _pct_to_logratio))
+                ax_pct = ax_histx.secondary_xaxis('top', functions=(_db_to_pct, _pct_to_db))
                 ax_pct.set_xlabel("Power Change (%)", fontsize=9)
                 ax_pct.xaxis.set_major_locator(MaxNLocator(nbins=5))
             except (AttributeError, TypeError, ValueError):
@@ -1319,7 +1320,7 @@ def plot_power_roi_scatter(
         _generate_correlation_scatter(
             x_data=overall_vals,
             y_data=y,
-            x_label="log10(power/baseline [-5–0 s])",
+            x_label="10·log10(power/baseline [-5–0 s]) (dB)",
             y_label="Rating",
             title_prefix=f"{band_title} power vs rating — Overall",
             band_color=band_color,
@@ -1339,7 +1340,11 @@ def plot_power_roi_scatter(
             Z_part = Z_df_full.iloc[:n_len_pt]
             x_res_sr, y_res_sr, n_res = _partial_residuals_xy_given_Z(x_part, y_part, Z_part, method_code)
             if n_res >= 5:
-                residual_xlabel = "Partial residuals (ranked) of log10(power/baseline)" if method_code == "spearman" else "Partial residuals of log10(power/baseline)"
+                residual_xlabel = (
+                    "Partial residuals (ranked) of 10·log10(power/baseline) (dB)"
+                    if method_code == "spearman"
+                    else "Partial residuals of 10·log10(power/baseline) (dB)"
+                )
                 residual_ylabel = "Partial residuals (ranked) of rating" if method_code == "spearman" else "Partial residuals of rating"
                 
                 _generate_correlation_scatter(
@@ -1366,7 +1371,7 @@ def plot_power_roi_scatter(
             _generate_correlation_scatter(
                 x_data=overall_vals,
                 y_data=temp_series,
-                x_label="log10(power/baseline [-5–0 s])",
+                x_label="10·log10(power/baseline [-5–0 s]) (dB)",
                 y_label="Temperature (°C)",
                 title_prefix=f"{band_title} power vs temperature — Overall",
                 band_color=band_color,
@@ -1386,7 +1391,11 @@ def plot_power_roi_scatter(
                 Z_part2 = Z_df_temp.iloc[:n_len_pt2]
                 x2_res_sr, y2_res_sr, n2_res = _partial_residuals_xy_given_Z(x_part2, y_part2, Z_part2, method2_code)
                 if n2_res >= 5:
-                    residual_xlabel = "Partial residuals (ranked) of log10(power/baseline)" if method2_code == "spearman" else "Partial residuals of log10(power/baseline)"
+                    residual_xlabel = (
+                        "Partial residuals (ranked) of 10·log10(power/baseline) (dB)"
+                        if method2_code == "spearman"
+                        else "Partial residuals of 10·log10(power/baseline) (dB)"
+                    )
                     residual_ylabel = "Partial residuals (ranked) of temperature (°C)" if method2_code == "spearman" else "Partial residuals of temperature (°C)"
                     
                     _generate_correlation_scatter(
@@ -1413,7 +1422,7 @@ def plot_power_roi_scatter(
             _generate_correlation_scatter(
                 x_data=roi_vals,
                 y_data=y,
-                x_label="log10(power/baseline [-5–0 s])",
+                x_label="10·log10(power/baseline [-5–0 s]) (dB)",
                 y_label="Rating",
                 title_prefix=f"{band_title} power vs rating — {roi}",
                 band_color=band_color,
@@ -1434,7 +1443,11 @@ def plot_power_roi_scatter(
                 Z_part = Z_df_full.iloc[:n_len_pt]
                 x_res_sr, y_res_sr, n_res = _partial_residuals_xy_given_Z(x_part, y_part, Z_part, method_code)
                 if n_res >= 5:
-                    residual_xlabel = "Partial residuals (ranked) of log10(power/baseline)" if method_code == "spearman" else "Partial residuals of log10(power/baseline)"
+                    residual_xlabel = (
+                        "Partial residuals (ranked) of 10·log10(power/baseline) (dB)"
+                        if method_code == "spearman"
+                        else "Partial residuals of 10·log10(power/baseline) (dB)"
+                    )
                     residual_ylabel = "Partial residuals (ranked) of rating" if method_code == "spearman" else "Partial residuals of rating"
                     
                     _generate_correlation_scatter(
@@ -1462,7 +1475,7 @@ def plot_power_roi_scatter(
                 _generate_correlation_scatter(
                     x_data=roi_vals,
                     y_data=temp_series,
-                    x_label="log10(power/baseline [-5–0 s])",
+                    x_label="10·log10(power/baseline [-5–0 s]) (dB)",
                     y_label="Temperature (°C)",
                     title_prefix=f"{band_title} power vs temperature — {roi}",
                     band_color=band_color,
@@ -1483,7 +1496,11 @@ def plot_power_roi_scatter(
                     Z_part2 = Z_df_temp.iloc[:n_len_pt2]
                     x2_res_sr, y2_res_sr, n2_res = _partial_residuals_xy_given_Z(x_part2, y_part2, Z_part2, method2_code)
                     if n2_res >= 5:
-                        residual_xlabel = "Partial residuals (ranked) of log10(power/baseline)" if method2_code == "spearman" else "Partial residuals of log10(power/baseline)"
+                        residual_xlabel = (
+                            "Partial residuals (ranked) of 10·log10(power/baseline) (dB)"
+                            if method2_code == "spearman"
+                            else "Partial residuals of 10·log10(power/baseline) (dB)"
+                        )
                         residual_ylabel = "Partial residuals (ranked) of temperature (°C)" if method2_code == "spearman" else "Partial residuals of temperature (°C)"
                         
                         _generate_correlation_scatter(
@@ -1550,7 +1567,7 @@ def plot_power_behavior_correlation(pow_df: pd.DataFrame, y: pd.Series, bands: L
             x_line = np.linspace(x_valid.min(), x_valid.max(), 100)
             axes[i].plot(x_line, p(x_line), 'r--', alpha=0.8)
             
-            axes[i].set_xlabel(f'{band.capitalize()} Power\n(log10(power/baseline))')
+            axes[i].set_xlabel(f'{band.capitalize()} Power\n(10·log10(power/baseline) (dB))')
             axes[i].set_ylabel('Behavioral Rating')
             axes[i].set_title(f'{band.capitalize()} Power vs Behavior')
             axes[i].grid(True, alpha=0.3)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Arguments:
 - **Frequency Bands**: Automatic segmentation into theta (4-8 Hz), alpha (8-13 Hz), beta (13-30 Hz), gamma (30-100 Hz)
 
 **2. Baseline Correction:**
-- **Method**: Log-ratio baseline correction (`mode='logratio'`) for relative power changes
+- **Method**: Log-ratio baseline correction (`mode='logratio'`; returns 10·log10(power/baseline) in dB) for relative power changes
 - **Baseline Window**: Pre-stimulus period `(None, 0.0)` seconds
 - **Statistical Rationale**: Log-ratio provides interpretable percent change from baseline and normalizes across frequency bands
 


### PR DESCRIPTION
## Summary
- Label baseline-normalized power as 10·log10(power/baseline) in dB across plotting utilities
- Add helpers for converting between dB and percent change and update scatter/axis labels
- Document that `mode='logratio'` returns decibel values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b738c51a9483319257f2b921558ac6