### PR TITLE
Use robust vlim for ROI TFR plots

### DIFF
--- a/eeg_config.yaml
+++ b/eeg_config.yaml
@@ -353,7 +353,11 @@ analysis:
     do_group_default: false
     group_only_default: false
     build_reports_default: false
-    
+
+  # Feature engineering plots
+  feature_engineering:
+    tfr_spectrogram_vlim: null  # Positive value to override robust vlim for ROI spectrograms
+
   # Raw-to-BIDS conversion
   raw_to_bids:
     default_montage: "easycap-M1"


### PR DESCRIPTION
## Summary
- compute symmetric color limits via `_robust_sym_vlim` for ROI spectrograms
- add optional `analysis.feature_engineering.tfr_spectrogram_vlim` override

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73d015b6c8331869114472a77da91