### PR TITLE
Externalize ROI and baseline parameters to YAML config

### DIFF
--- a/02_time_frequency_analysis.py
+++ b/02_time_frequency_analysis.py
@@ -77,7 +77,7 @@ DEFAULT_PLATEAU_TMIN = config.analysis.time_frequency.default_plateau_tmin
 DEFAULT_PLATEAU_TMAX = config.analysis.time_frequency.default_plateau_tmax
 
 # Minimum baseline coverage
-MIN_BASELINE_SAMPLES = 5
+MIN_BASELINE_SAMPLES = config.analysis.time_frequency.min_baseline_samples
 
 
 def _validate_baseline_indices(
@@ -114,23 +114,13 @@ def _sanitize(name: str) -> str:
 
 
 def _roi_definitions() -> Dict[str, list[str]]:
-    """Scientifically reasonable sensor-space ROIs using 10-10 labels.
+    """Sensor-space ROIs defined in the configuration file.
 
     Patterns are regexes matched case-insensitively against channel names.
     """
     return {
-        # Frontal pole + frontal
-        "Frontal": [r"^(Fpz|Fp[12]|AFz|AF[3-8]|Fz|F[1-8])$"],
-        # Central strip only (C-series)
-        "Central": [r"^(Cz|C[1-6])$"],
-        # Parietal (P-series)
-        "Parietal": [r"^(Pz|P[1-8])$"],
-        # Occipital and parieto-occipital
-        "Occipital": [r"^(Oz|O[12]|POz|PO[3-8])$"],
-        # Lateral temporal regions
-        "Temporal": [r"^(T7|T8|TP7|TP8|FT7|FT8)$"],
-        # Bilateral sensorimotor strip (FC/C/CP around hand knob)
-        "Sensorimotor": [r"^(FC[234]|FCz)$", r"^(C[234]|Cz)$", r"^(CP[234]|CPz)$"],
+        roi: list(patterns)
+        for roi, patterns in config.analysis.time_frequency.rois.items()
     }
 
 

--- a/03_feature_engineering.py
+++ b/03_feature_engineering.py
@@ -42,7 +42,7 @@ PLATEAU_END = _constants["PLATEAU_END"]
 TARGET_COLUMNS = _constants["TARGET_COLUMNS"]
 
 # Minimum number of samples required in the baseline window
-MIN_BASELINE_SAMPLES = 5
+MIN_BASELINE_SAMPLES = config.analysis.feature_engineering.min_baseline_samples
 # Baseline window for TFR computations (start, end) in seconds
 TFR_BASELINE = tuple(config.analysis.time_frequency.baseline_window)
 

--- a/eeg_config.yaml
+++ b/eeg_config.yaml
@@ -349,6 +349,18 @@ analysis:
       markeredgecolor: 'k'
       linewidth: 0.5
       markersize: 4
+    # Sensor-space ROI definitions and baseline requirements
+    min_baseline_samples: 5  # Minimum samples required in baseline window
+    rois:
+      Frontal: ["^(Fpz|Fp[12]|AFz|AF[3-8]|Fz|F[1-8])$"]
+      Central: ["^(Cz|C[1-6])$"]
+      Parietal: ["^(Pz|P[1-8])$"]
+      Occipital: ["^(Oz|O[12]|POz|PO[3-8])$"]
+      Temporal: ["^(T7|T8|TP7|TP8|FT7|FT8)$"]
+      Sensorimotor:
+        - "^(FC[234]|FCz)$"
+        - "^(C[234]|Cz)$"
+        - "^(CP[234]|CPz)$"
     # Default CLI parameters
     n_perm_default: 0
     do_group_default: false
@@ -359,6 +371,11 @@ analysis:
   raw_to_bids:
     default_montage: "easycap-M1"
     default_line_freq: 60.0
+
+  # Feature engineering analysis settings
+  feature_engineering:
+    min_baseline_samples: 5  # Minimum samples required in baseline window
+    tfr_spectrogram_vlim: null  # Optional override for TFR spectrogram limits
 
   # Behavior analysis settings (04_behavior_feature_analysis.py)
   behavior_analysis:


### PR DESCRIPTION
## Summary
- Move sensor-space ROI patterns and baseline sample count into `eeg_config.yaml`
- Read `min_baseline_samples` and ROI definitions from config in time-frequency and feature-engineering scripts
- Add feature engineering config block to central YAML

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ab1e7f9c8331ac58c6e7e3ab7649