### PR TITLE
Support group-level EEG visualizations across scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a comprehensive EEG analysis pipeline built on top of M
 - **Feature Engineering**: Extract ML-ready features from EEG power and connectivity
 - **Behavioral Analysis**: Correlate EEG features with behavioral measures using advanced statistical methods
 - **Pain Decoding**: State-of-the-art machine learning models with rigorous cross-validation and statistical validation
+- **Group-Level Support**: Core analysis scripts (01–04) accept multiple subjects and aggregate results to produce grand-average statistics and visualizations
 
 All scripts live in `eeg_pipeline/` and write outputs into a BIDS-style tree under `eeg_pipeline/bids_output/` and its `derivatives/` subfolder.
 
@@ -407,6 +408,8 @@ Arguments:
 - `--group` (flag): Also aggregate group-level results across subjects.
 - `--group-only` (flag): Only run group-level aggregation, skip per-subject analysis.
 - `--report` (flag): Build per-subject MNE HTML report.
+
+Group-level runs merge per-subject ROI power correlations for both pain ratings and stimulus temperature, and summarize connectivity ROI statistics across participants with FDR correction.
 
 **Detailed Analysis Pipeline:**
 

--- a/tests/test_group_visualizations.py
+++ b/tests/test_group_visualizations.py
@@ -1,0 +1,79 @@
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import mne
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(fname, name):
+    spec = importlib.util.spec_from_file_location(name, ROOT / fname)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_foundational_group(tmp_path):
+    fa = _load_module('01_foundational_analysis.py', 'fa')
+    fa.DERIV_ROOT = tmp_path
+    fa.PLOTS_SUBDIR = 'foundational'
+    fa._save_fig = lambda *args, **kwargs: None
+    fa.ERP_PICKS = ['Cz']
+    info = mne.create_info(['Cz'], sfreq=100, ch_types='eeg')
+    data = np.random.randn(1, 100)
+    ev = mne.EvokedArray(data, info, tmin=0)
+    results = [
+        {'pain_evokeds': {'painful': ev, 'non-painful': ev}, 'temp_evokeds': {'low': ev}},
+        {'pain_evokeds': {'painful': ev, 'non-painful': ev}, 'temp_evokeds': {'low': ev}},
+    ]
+    fa.aggregate_group_level(results)
+    out_dir = tmp_path / 'group' / 'eeg' / 'plots' / 'foundational'
+    assert out_dir.exists()
+
+
+def test_time_frequency_group(tmp_path):
+    tf = _load_module('02_time_frequency_analysis.py', 'tf')
+    tf.DERIV_ROOT = tmp_path
+    tf._save_fig = lambda *args, **kwargs: None
+    tf.BAND_BOUNDS = {'alpha': (8, 12)}
+    info = mne.create_info(['Cz'], sfreq=100, ch_types='eeg')
+    epochs_data = np.random.randn(1, 1, 100)
+    epochs = mne.EpochsArray(epochs_data, info)
+    tfr1 = mne.time_frequency.tfr_morlet(epochs, freqs=np.array([10]), n_cycles=2, return_itc=False)
+    tfr2 = mne.time_frequency.tfr_morlet(epochs, freqs=np.array([10]), n_cycles=2, return_itc=False)
+    tf.aggregate_group_level([tfr1, tfr2], plateau_tmin=0, plateau_tmax=0.5)
+    out_dir = tmp_path / 'group' / 'eeg' / 'plots' / '02_time_frequency_analysis'
+    assert out_dir.exists()
+
+
+def test_feature_engineering_group(tmp_path):
+    fe = _load_module('03_feature_engineering.py', 'fe')
+    fe.DERIV_ROOT = tmp_path
+    fe._save_fig = lambda *args, **kwargs: None
+    subjects = ['001', '002']
+    for sub in subjects:
+        fdir = tmp_path / f'sub-{sub}' / 'eeg' / 'features'
+        fdir.mkdir(parents=True)
+        pd.DataFrame({'a': [1.0], 'b': [2.0]}).to_csv(fdir / 'features_all.tsv', sep='\t', index=False)
+        pd.DataFrame({'rating': [5]}).to_csv(fdir / 'target_vas_ratings.tsv', sep='\t', index=False)
+    fe.aggregate_group_level(subjects)
+    out_file = tmp_path / 'group' / 'eeg' / 'features' / 'features_all.tsv'
+    assert out_file.exists()
+
+
+def test_behavior_feature_group(tmp_path):
+    bf = _load_module('04_behavior_feature_analysis.py', 'bf')
+    bf.DERIV_ROOT = tmp_path
+    bf._save_fig = lambda *args, **kwargs: None
+    subjects = ['001', '002']
+    for sub in subjects:
+        sdir = tmp_path / f'sub-{sub}' / 'eeg' / 'stats'
+        sdir.mkdir(parents=True)
+        pd.DataFrame({'roi': ['roi1'], 'band': ['alpha'], 'r': [0.1]}).to_csv(
+            sdir / 'corr_stats_pow_roi_vs_rating.tsv', sep='\t', index=False
+        )
+    bf.aggregate_group_level(subjects)
+    out_file = tmp_path / 'group' / 'eeg' / 'stats' / 'group_corr_pow_roi_vs_rating.tsv'
+    assert out_file.exists()


### PR DESCRIPTION
## Summary
- grand-average ERPs across subjects and produce group plots in foundational analysis
- combine per-subject time-frequency data and render group TFR/topomap figures
- concatenate feature matrices across participants to export group summaries and correlation heatmaps
- aggregate behavioral-feature correlations across subjects with FDR correction and group-level plots
- pool ROI power–temperature correlations and connectivity summaries across participants for group visualizations
- document that core scripts now support multi-subject aggregation
- add pooled band-power distribution plots when aggregating features across subjects
- add tests exercising group-level aggregation helpers across foundational, time–frequency, feature, and behavioral analyses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b84581ced08331982711a742c3570d